### PR TITLE
Add support for Sine groupboxes.

### DIFF
--- a/Nebula/content/Transparent-settings.css
+++ b/Nebula/content/Transparent-settings.css
@@ -9,7 +9,7 @@
   --zen-settings-secondary-background: transparent !important;
 }
 
-groupbox{
+groupbox:not(#sineInstallationGroup:popover-open){
 /*   background: var(--zen-colors-tertiary) !important; */
   background: var(--zen-colors-border-contrast) !important;
   border: none


### PR DESCRIPTION
In an attempt to make Sine's backgrounds compatible with Nebula, I need this style changed to exclude Sine's groupbox. Other than that, all Nebula-related issues will be fixed in the new Sine version.