### PR TITLE
Add marginless compact mod option

### DIFF
--- a/Nebula/Nebula-config.css
+++ b/Nebula/Nebula-config.css
@@ -55,13 +55,16 @@ without searching through the code directly */
     /* 2. If you want NoGaps mod (ONLY for single toolbar mode):
         Go to about:config and add a "boolean" "nebula-nogaps-mod" and set it to true */
 
-    /* 3. If you want background for compact sidebar when websites are transparent:
+    /* 3. If you want marginless compact mod:
+        Go to about:config and add a "boolean" "nebula-marginless-compact-mod" and set it to true */
+
+    /* 4. If you want background for compact sidebar when websites are transparent:
         Go to about:config and add a "boolean" "nebula-compact-mode-sidebar-bg" and set it to true */
 
-    /* 4. If you want to remove the background on Pinned tabs:
+    /* 5. If you want to remove the background on Pinned tabs:
         Go to about:config and add a "boolean" "nebula-pinned-tabs-bg" and set it to true */
 
-    /* 5. If you want to remove the workspace indicator:
+    /* 6. If you want to remove the workspace indicator:
         Go to about:config and add a "boolean" "nebula-remove-workspace-indicator" and set it to true */
 
 :root {

--- a/Nebula/Nebula-config.css
+++ b/Nebula/Nebula-config.css
@@ -55,8 +55,8 @@ without searching through the code directly */
     /* 2. If you want NoGaps mod (ONLY for single toolbar mode):
         Go to about:config and add a "boolean" "nebula-nogaps-mod" and set it to true */
 
-    /* 3. If you want marginless compact mod:
-        Go to about:config and add a "boolean" "nebula-marginless-compact-mod" and set it to true */
+    /* 3. If you want NoGaps only in compact mode:
+        Go to about:config and add a "boolean" "nebula-nogaps-compact-mod" and set it to true */
 
     /* 4. If you want background for compact sidebar when websites are transparent:
         Go to about:config and add a "boolean" "nebula-compact-mode-sidebar-bg" and set it to true */

--- a/Nebula/modules/General-UI.css
+++ b/Nebula/modules/General-UI.css
@@ -56,9 +56,9 @@ hbox.browserSidebarContainer,
   }
 }
 
-/* ----------------- MARGINLESS COMPACT MOD ----------------- */
+/* ----------------- NOGAPS COMPACT MOD ----------------- */
 
-@media (-moz-bool-pref: "nebula-marginless-compact-mod") {
+@media (-moz-bool-pref: "nebula-nogaps-compact-mod") {
   :root[zen-compact-mode="true"]:not([customizing]) {
       #zen-appcontent-wrapper:not(:has(#tabbrowser-tabpanels[zen-split-view]), :has(#zen-sidebar-web-panel:not([hidden]):not([pinned]))) {
           margin: 0 !important;

--- a/Nebula/modules/General-UI.css
+++ b/Nebula/modules/General-UI.css
@@ -56,6 +56,32 @@ hbox.browserSidebarContainer,
   }
 }
 
+/* ----------------- MARGINLESS COMPACT MOD ----------------- */
+
+@media (-moz-bool-pref: "nebula-marginless-compact-mod") {
+  :root[zen-compact-mode="true"]:not([customizing]) {
+      #zen-appcontent-wrapper:not(:has(#tabbrowser-tabpanels[zen-split-view]), :has(#zen-sidebar-web-panel:not([hidden]):not([pinned]))) {
+          margin: 0 !important;
+
+          #zen-tabbox-wrapper {
+              margin: 0 !important;
+          }
+
+          #zen-tabbox-wrapper .browserSidebarContainer,
+          #zen-tabbox-wrapper browser {
+              margin: 0 !important;
+              border-radius: 0 !important;
+          }
+
+          @media (-moz-bool-pref: "zen.view.use-single-toolbar") {
+              #zen-appcontent-navbar-container {
+                  visibility: collapse !important;
+              }
+          }
+      }
+  }
+}
+
 /* ------------------- FLOATING STATUSBAR ------------------- */
 /* Credit to the mod */
 

--- a/Nebula/modules/General-UI.css
+++ b/Nebula/modules/General-UI.css
@@ -74,9 +74,14 @@ hbox.browserSidebarContainer,
           }
 
           @media (-moz-bool-pref: "zen.view.use-single-toolbar") {
-              #zen-appcontent-navbar-container {
-                  visibility: collapse !important;
-              }
+            #zen-appcontent-wrapper {
+                position: relative;
+            }
+
+            #zen-appcontent-navbar-wrapper {
+                position: absolute;
+                width: 100% !important;
+            }
           }
       }
   }

--- a/preferences.json
+++ b/preferences.json
@@ -177,6 +177,11 @@
     },
     {
         "type": "checkbox",
+        "property": "nebula-marginless-compact-mod",
+        "label": "Enables Marginless Compact mod."
+    },
+    {
+        "type": "checkbox",
         "property": "nebula-compact-mode-sidebar-bg",
         "label": "Enables background for compact sidebar when sites are transparent."
     },

--- a/preferences.json
+++ b/preferences.json
@@ -177,7 +177,7 @@
     },
     {
         "type": "checkbox",
-        "property": "nebula-marginless-compact-mod",
+        "property": "nebula-nogaps-compact-mod",
         "label": "Enables Marginless Compact mod."
     },
     {


### PR DESCRIPTION
This change introduces a new CSS block activated via the `nebula-marginless-compact-mod` boolean preference. When enabled, and in `zen-compact-mode`, it removes margins around the web content.

Additionally, if the `zen.view.use-single-toolbar` preference is active, the app content navbar container is collapsed for a cleaner, more full-screen appearance.

I also modified the documentation.