### PR TITLE
Modified the display of the audio icon

### DIFF
--- a/Nebula/modules/Sound-icon.css
+++ b/Nebula/modules/Sound-icon.css
@@ -1,5 +1,3 @@
-
-@-moz-document url-prefix("chrome:") {
 /* ------------------------- QUIETIFY SOUND ICON ------------------------- */
 
 span[part="button"].button-background {
@@ -104,5 +102,4 @@ span[part="button"].button-background {
         border: 3px solid var(--toolbarbutton-icon-fill-attention) !important;
       }
     }
-  }  
-}
+  }

--- a/Nebula/modules/Sound-icon.css
+++ b/Nebula/modules/Sound-icon.css
@@ -1,3 +1,5 @@
+
+@-moz-document url-prefix("chrome:") {
 /* ------------------------- QUIETIFY SOUND ICON ------------------------- */
 
 span[part="button"].button-background {
@@ -61,14 +63,14 @@ span[part="button"].button-background {
       }
     }
   
-    @media not (-moz-pref("zen.view.sidebar-expanded")) {
-      .tabbrowser-tab:is([soundplaying], [muted], [activemedia-blocked]):hover
+
+      .tabbrowser-tab:is([soundplaying], [muted], [activemedia-blocked])
         img {
         opacity: 1 !important;
         transition: opacity 0.1s ease-out !important;
       }
   
-      .tabbrowser-tab:is([soundplaying], [muted], [activemedia-blocked]):hover
+      .tabbrowser-tab:is([soundplaying], [muted], [activemedia-blocked])
         .tab-icon-overlay {
         margin: 0px !important;
         transition: opacity 0.25s ease-out, transform 0.25s ease-out !important;
@@ -78,7 +80,7 @@ span[part="button"].button-background {
       .tabbrowser-tab:is([soundplaying], [muted], [activemedia-blocked]) .tab-icon-overlay {
         transition: opacity 0.25s ease-in, transform 0.25s ease-in !important;
       }
-    }
+    
   
     #zen-essentials-container {
       .tab-icon-overlay:is([soundplaying], [muted], [activemedia-blocked]) {
@@ -102,4 +104,5 @@ span[part="button"].button-background {
         border: 3px solid var(--toolbarbutton-icon-fill-attention) !important;
       }
     }
-  }
+  }  
+}


### PR DESCRIPTION
Only a few changes were made to keep the audio icon always displayed in a reduced size at the top right of the website icon.
I think this kind of audio icon is more refined and won't cover up the website icon.
This might be a matter of personal preference. If you all like it, please merge this PR，otherwise, I will abandon this PR. Thank you.
![PixPin_2025-06-01_13-27-21](https://github.com/user-attachments/assets/6684d702-a332-4661-ae70-508f9938c257)
![PixPin_2025-06-01_13-28-03](https://github.com/user-attachments/assets/7be2e3ae-9475-455d-b33f-52a558efd570)
![PixPin_2025-06-01_13-28-19](https://github.com/user-attachments/assets/5aa36c4b-cd3b-4403-90e7-1a219ef30c1c)
