### PR TITLE
fix(Workspace-buttons): add horizontal scroll and prevent button shrinking

### DIFF
--- a/Nebula/modules/Workspace-buttons.css
+++ b/Nebula/modules/Workspace-buttons.css
@@ -30,16 +30,13 @@
     box-shadow: 0 2px 12px rgba(0,0,0,0.1) !important;
     transition: box-shadow 0.35s ease-out, background-color 0.35s ease-out;
 
-    /* --- CORREÇÃO APLICADA --- */
-    /* Define uma largura máxima. Você pode ajustar este valor como preferir. */
     max-width: 280px; 
-    /* Habilita a rolagem horizontal quando o conteúdo transborda. */
+
     overflow-x: auto !important;
-    /* Oculta a barra de rolagem, mas mantém a funcionalidade de scroll. */
+
     scrollbar-width: none !important;
   }
 
-  /* Oculta a barra de rolagem em navegadores baseados em WebKit (boa prática) */
   #zen-workspaces-button::-webkit-scrollbar {
     display: none;
   }
@@ -51,8 +48,7 @@
 
   /* Default subview button styling */
   #zen-workspaces-button .subviewbutton {
-    /* --- CORREÇÃO APLICADA --- */
-    /* Impede que os botões flexíveis encolham. Esta é a chave da solução. */
+ 
     flex-shrink: 0 !important;
 
     border-radius: calc(var(--nebula-border-radius) - 4.5px) !important;
@@ -115,9 +111,6 @@
       box-shadow: 0 2px 12px rgba(0,0,0,0) !important;
       transition: box-shadow 0.35s ease-out, background-color 0.35s ease-out;
       
-      /* --- CORREÇÃO APLICADA --- */
-      /* A propriedade 'overflow: visible' foi removida para permitir a rolagem. */
-      /* As propriedades de rolagem da regra base já se aplicam aqui. */
     }
 
     #zen-workspaces-button:hover {
@@ -233,9 +226,6 @@
       box-shadow: 0 2px 12px rgba(0,0,0,0.1) !important;
       transition: box-shadow 0.35s ease-out, background-color 0.35s ease-out;
 
-      /* --- CORREÇÃO APLICADA --- */
-      /* A propriedade 'overflow: visible' foi removida para permitir a rolagem. */
-      /* As propriedades de rolagem da regra base já se aplicam aqui. */
     }
 
     #zen-workspaces-button:hover {

--- a/Nebula/modules/Workspace-buttons.css
+++ b/Nebula/modules/Workspace-buttons.css
@@ -1,330 +1,354 @@
-/* ------------------------------ Workspace Button Styles ------------------------------ */
+@-moz-document url-prefix("chrome:") {
+  /* ------------------------------ Workspace Button Styles ------------------------------ */
 
-/* make workspace indicator have nebula theme background on hover */
-.zen-current-workspace-indicator::before {
-  box-shadow: 0 0px 8px transparent !important;
-  border-radius: var(--nebula-border-radius) !important;
-  transition: background-color 0.3s ease, box-shadow 0.3s ease !important;
-}
+  /* make workspace indicator have nebula theme background on hover */
+  .zen-current-workspace-indicator::before {
+    box-shadow: 0 0px 8px transparent !important;
+    border-radius: var(--nebula-border-radius) !important;
+    transition: background-color 0.3s ease, box-shadow 0.3s ease !important;
+  }
 
-.zen-current-workspace-indicator:hover::before {
-  background-color: var(--nebula-color) !important;
-  box-shadow: 0 0px 3px light-dark(rgba(255, 255, 255, 0.05), rgba(0, 0, 0, 0.55)) !important;
-  z-index: -1 !important;
-}
+  .zen-current-workspace-indicator:hover::before {
+    background-color: var(--nebula-color) !important;
+    box-shadow: 0 0px 3px light-dark(rgba(255, 255, 255, 0.05), rgba(0, 0, 0, 0.55)) !important;
+    z-index: -1 !important;
+  }
 
-/* Common animations */
-@keyframes emojiPulse {
-  0% { transform: scale(0.85); }
-  50% { transform: scale(1.15); }
-  100% { transform: scale(1); }
-}
+  /* Common animations */
+  @keyframes emojiPulse {
+    0% { transform: scale(0.85); }
+    50% { transform: scale(1.15); }
+    100% { transform: scale(1); }
+  }
 
-/* Base Styling (Style 1 - Default) */
-#zen-workspaces-button {
-  container-type: initial !important;
-  width: auto !important;
-  padding: 3px !important;
-  border-radius: calc(var(--nebula-border-radius) - 2px) !important;
-  background-color: light-dark(rgba(255,255,255,0.1), rgba(0,0,0,0.2)) !important;
-  box-shadow: 0 2px 12px rgba(0,0,0,0.1) !important;
-  transition: box-shadow 0.35s ease-out, background-color 0.35s ease-out;
-}
-
-#zen-workspaces-button:hover {
-  background-color: light-dark(rgba(255,255,255,0.25), rgba(0,0,0,0.35)) !important;
-  box-shadow: 0 2px 12px rgba(0,0,0,0.5) !important;
-}
-
-/* Default subview button styling */
-#zen-workspaces-button .subviewbutton {
-  border-radius: calc(var(--nebula-border-radius) - 4.5px) !important;
-  font-size: 16px !important;
-  opacity: 0.75 !important;
-  filter: grayscale(var(--nebula-workspace-grayscale, 100%)) !important;
-  transition:
-    background-color 0.2s ease,
-    filter 0.3s ease,
-    opacity 0.3s ease-out,
-    transform 0.2s ease !important;
-  --toolbarbutton-hover-background: color-mix(
-    in srgb,
-    var(--zen-branding-bg-reverse) 10%,
-    transparent 90%
-  ) !important;
-}
-
-#zen-workspaces-button .subviewbutton:hover {
-  background-color: light-dark(rgba(255,255,255,0), rgba(100,100,100,0)) !important;
-  filter: grayscale(0%) !important;
-  opacity: 0.9 !important;
-}
-
-#zen-workspaces-button .subviewbutton:hover > img,
-#zen-workspaces-button .subviewbutton:hover > svg {
-  opacity: 1 !important;
-}
-
-#zen-workspaces-button .subviewbutton:active {
-  background-color: var(--toolbarbutton-active-background) !important;
-  filter: grayscale(0%) !important;
-  transform: scale(0.85) !important;
-}
-
-#zen-workspaces-button .subviewbutton:active:hover {
-  transform: scale(0.9) !important;
-}
-
-#zen-workspaces-button .subviewbutton[active] {
-  background-color: light-dark(rgba(255,255,255,0.12), rgba(255,255,255,0.07)) !important;
-  box-shadow: 0 0 4px rgba(0,0,0,0.2) !important;
-  overflow: hidden !important;
-  position: relative;
-  filter: grayscale(0%) !important;
-  opacity: 1 !important;
-  animation: emojiPulse 0.5s ease-out;
-}
-
-/* Style 0 (Minimal Style) */
-@media (-moz-pref("nebula-workspace-style", 0)) {
-  /* Container styling */
+  /* Base Styling (Style 1 - Default) */
   #zen-workspaces-button {
-    height: 30px !important;
+    container-type: initial !important;
     padding: 3px !important;
-    position: relative !important;
-    overflow: visible !important;
-    z-index: 1;
-    border-radius: calc(var(--nebula-border-radius) - 2px) !important;
-    background-color: transparent !important;
-    box-shadow: 0 2px 12px rgba(0,0,0,0) !important;
-    transition: box-shadow 0.35s ease-out, background-color 0.35s ease-out;
-  }
-
-  #zen-workspaces-button:hover {
-    box-shadow: 0 2px 12px rgba(0,0,0,0) !important;
-    background-color: transparent !important;
-  }
-
-  /* Style 0 button styling - resets and custom styles */
-  #zen-workspaces-button .subviewbutton {
-    /* Reset defaults */
-    border-radius: unset !important;
-    font-size: unset !important;
-    opacity: unset !important;
-    background-color: transparent !important;
-    box-shadow: none !important;
-    animation: none !important;
-    --toolbarbutton-hover-background: unset !important;
-
-    /* Custom styling */
-    display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
-    height: 40px !important;
-    border-radius: 12px !important;
-    font-size: 1.25em !important;
-    transform: scale(1) !important;
-    transform-origin: bottom center !important;
-    transition: 
-      transform 0.25s ease, 
-      filter 0.3s ease, 
-      opacity 0.3s ease-out, 
-      color 0.3s ease-out !important;
-    color: transparent !important; /* Hide emoji text by default */
-  }
-
-  /* Hover states */
-  #zen-workspaces-button .subviewbutton:hover {
-    transform: scale(1.4) !important;
-    filter: grayscale(0%) !important;
-    opacity: 1 !important;
-    z-index: 3 !important;
-    font-size: 1.35em !important;
-    color: inherit !important;
-  }
-
-  #zen-workspaces-button .subviewbutton:active {
-    background-color: transparent !important;
-    transform: scale(1) !important;
-    filter: grayscale(var(--nebula-workspace-grayscale, 100%)) !important;
-  }
-
-  #zen-workspaces-button .subviewbutton:active:hover {
-    transform: scale(1) !important;
-  }
-
-  #zen-workspaces-button .subviewbutton[active] {
-    background-color: transparent !important;
-    box-shadow: none !important;
-    overflow: unset !important;
-    position: static !important;
-    animation: none !important;
-    filter: grayscale(0%) !important;
-    opacity: 1 !important;
-    color: inherit !important;
-  }
-
-  /* Sibling hover effects */
-  #zen-workspaces-button .subviewbutton:hover + .subviewbutton,
-  #zen-workspaces-button .subviewbutton:has(+ .subviewbutton:hover) {
-    transform: scale(1.15) !important;
-    z-index: 2 !important;
-    opacity: 0.9 !important;
-  }
-
-  #zen-workspaces-button .subviewbutton:hover + .subviewbutton + .subviewbutton,
-  #zen-workspaces-button .subviewbutton:has(+ .subviewbutton + .subviewbutton:hover) {
-    transform: scale(1) !important;
-    z-index: 1 !important;
-    opacity: 0.85 !important;
-  }
-
-  /* Indicator dot */
-  #zen-workspaces-button .subviewbutton::before {
-    content: "•";
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -56.5%);
-    font-size: 2em;
-    color: light-dark(white, rgba(255,255,255,0.35));
-    opacity: 1;
-    pointer-events: none;
-    transition: opacity 0.3s ease;
-  }
-
-  #zen-workspaces-button .subviewbutton:hover::before,
-  #zen-workspaces-button .subviewbutton[active]::before {
-    opacity: 0;
-  }
-}
-
-/* Style 2 (Advanced Style) */
-@media (-moz-pref("nebula-workspace-style", 2)) {
-  /* Container styling */
-  #zen-workspaces-button {
-    height: 30px !important;
-    width: auto !important;
-    padding: 3px !important;
-    position: relative !important;
-    overflow: visible !important;
-    z-index: 1;
     border-radius: calc(var(--nebula-border-radius) - 2px) !important;
     background-color: light-dark(rgba(255,255,255,0.1), rgba(0,0,0,0.2)) !important;
     box-shadow: 0 2px 12px rgba(0,0,0,0.1) !important;
     transition: box-shadow 0.35s ease-out, background-color 0.35s ease-out;
+
+    /* --- CORREÇÃO APLICADA --- */
+    /* Define uma largura máxima. Você pode ajustar este valor como preferir. */
+    max-width: 280px; 
+    /* Habilita a rolagem horizontal quando o conteúdo transborda. */
+    overflow-x: auto !important;
+    /* Oculta a barra de rolagem, mas mantém a funcionalidade de scroll. */
+    scrollbar-width: none !important;
+  }
+
+  /* Oculta a barra de rolagem em navegadores baseados em WebKit (boa prática) */
+  #zen-workspaces-button::-webkit-scrollbar {
+    display: none;
   }
 
   #zen-workspaces-button:hover {
-    box-shadow: 0 2px 12px rgba(0,0,0,0.5) !important;
     background-color: light-dark(rgba(255,255,255,0.25), rgba(0,0,0,0.35)) !important;
+    box-shadow: 0 2px 12px rgba(0,0,0,0.5) !important;
   }
 
-  /* Style 2 button styling - resets and custom styles */
+  /* Default subview button styling */
   #zen-workspaces-button .subviewbutton {
-    /* Reset defaults */
-    border-radius: unset !important;
-    font-size: unset !important;
-    opacity: unset !important;
-    background-color: transparent !important;
-    box-shadow: none !important;
-    animation: none !important;
-    --toolbarbutton-hover-background: unset !important;
+    /* --- CORREÇÃO APLICADA --- */
+    /* Impede que os botões flexíveis encolham. Esta é a chave da solução. */
+    flex-shrink: 0 !important;
 
-    /* Custom styling */
-    display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
-    height: 40px !important;
-    border-radius: 12px !important;
-    font-size: 1.25em !important;
-    transform: scale(1) !important;
-    transform-origin: bottom center !important;
-    transition: 
-      transform 0.25s ease, 
-      filter 0.3s ease, 
-      opacity 0.3s ease-out, 
-      color 0.3s ease-out !important;
-    color: transparent !important; /* Hide emoji text by default */
-  }
-
-  /* Hover states */
-  #zen-workspaces-button .subviewbutton:hover {
-    transform: scale(1.4) !important;
-    filter: grayscale(0%) !important;
-    opacity: 1 !important;
-    z-index: 3 !important;
-    font-size: 1.35em !important;
-    color: inherit !important;
-  }
-
-  #zen-workspaces-button .subviewbutton:active {
-    background-color: transparent !important;
-    transform: scale(1) !important;
+    border-radius: calc(var(--nebula-border-radius) - 4.5px) !important;
+    font-size: 16px !important;
+    opacity: 0.75 !important;
     filter: grayscale(var(--nebula-workspace-grayscale, 100%)) !important;
+    transition:
+      background-color 0.2s ease,
+      filter 0.3s ease,
+      opacity 0.3s ease-out,
+      transform 0.2s ease !important;
+    --toolbarbutton-hover-background: color-mix(
+      in srgb,
+      var(--zen-branding-bg-reverse) 10%,
+      transparent 90%
+    ) !important;
   }
 
-  #zen-workspaces-button .subviewbutton:active:hover {
-    transform: scale(1) !important;
-  }
-
-  #zen-workspaces-button .subviewbutton[active] {
-    background-color: transparent !important;
-    box-shadow: none !important;
-    overflow: unset !important;
-    position: static !important;
-    animation: none !important;
+  #zen-workspaces-button .subviewbutton:hover {
+    background-color: light-dark(rgba(255,255,255,0), rgba(100,100,100,0)) !important;
     filter: grayscale(0%) !important;
-    opacity: 1 !important;
-    color: inherit !important;
-  }
-
-  /* Sibling hover effects */
-  #zen-workspaces-button .subviewbutton:hover + .subviewbutton,
-  #zen-workspaces-button .subviewbutton:has(+ .subviewbutton:hover) {
-    transform: scale(1.15) !important;
-    z-index: 2 !important;
     opacity: 0.9 !important;
   }
 
-  #zen-workspaces-button .subviewbutton:hover + .subviewbutton + .subviewbutton,
-  #zen-workspaces-button .subviewbutton:has(+ .subviewbutton + .subviewbutton:hover) {
-    transform: scale(1) !important;
-    z-index: 1 !important;
-    opacity: 0.85 !important;
+  #zen-workspaces-button .subviewbutton:hover > img,
+  #zen-workspaces-button .subviewbutton:hover > svg {
+    opacity: 1 !important;
   }
 
-  /* Indicator dot */
-  #zen-workspaces-button .subviewbutton::before {
-    content: "•";
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -56.5%);
-    font-size: 2em;
-    color: light-dark(white, rgba(255,255,255,0.35));
-    opacity: 1;
-    pointer-events: none;
-    transition: opacity 0.3s ease;
+  #zen-workspaces-button .subviewbutton:active {
+    background-color: var(--toolbarbutton-active-background) !important;
+    filter: grayscale(0%) !important;
+    transform: scale(0.85) !important;
   }
 
-
-  #zen-workspaces-button .subviewbutton:hover::before,
-  #zen-workspaces-button .subviewbutton[active]::before {
-    opacity: 0;
+  #zen-workspaces-button .subviewbutton:active:hover {
+    transform: scale(0.9) !important;
   }
-}
 
-/* ------------------------------ Configuration Options ------------------------------ */
+  #zen-workspaces-button .subviewbutton[active] {
+    background-color: light-dark(rgba(255,255,255,0.12), rgba(255,255,255,0.07)) !important;
+    box-shadow: 0 0 4px rgba(0,0,0,0.2) !important;
+    overflow: hidden !important;
+    position: relative;
+    filter: grayscale(0%) !important;
+    opacity: 1 !important;
+    animation: emojiPulse 0.5s ease-out;
+  }
 
-/* Option to remove workspace name */
-@media (-moz-pref("nebula-remove-workspace-indicator")) {
-  
-.zen-current-workspace-indicator {
-  display: none !important;
-}
-  
-  #zen-tabs-wrapper {
-    padding-top: 4px; /* Add missing padding */
+  /* Style 0 (Minimal Style) */
+  @media (-moz-int-pref: nebula-workspace-style: 0) {
+    /* Container styling */
+    #zen-workspaces-button {
+      height: 30px !important;
+      padding: 3px !important;
+      position: relative !important;
+      z-index: 1;
+      border-radius: calc(var(--nebula-border-radius) - 2px) !important;
+      background-color: transparent !important;
+      box-shadow: 0 2px 12px rgba(0,0,0,0) !important;
+      transition: box-shadow 0.35s ease-out, background-color 0.35s ease-out;
+      
+      /* --- CORREÇÃO APLICADA --- */
+      /* A propriedade 'overflow: visible' foi removida para permitir a rolagem. */
+      /* As propriedades de rolagem da regra base já se aplicam aqui. */
+    }
+
+    #zen-workspaces-button:hover {
+      box-shadow: 0 2px 12px rgba(0,0,0,0) !important;
+      background-color: transparent !important;
+    }
+
+    /* Style 0 button styling - resets and custom styles */
+    #zen-workspaces-button .subviewbutton {
+      /* Reset defaults */
+      border-radius: unset !important;
+      font-size: unset !important;
+      opacity: unset !important;
+      background-color: transparent !important;
+      box-shadow: none !important;
+      animation: none !important;
+      --toolbarbutton-hover-background: unset !important;
+
+      /* Custom styling */
+      display: flex !important;
+      align-items: center !important;
+      justify-content: center !important;
+      height: 40px !important;
+      border-radius: 12px !important;
+      font-size: 1.25em !important;
+      transform: scale(1) !important;
+      transform-origin: bottom center !important;
+      transition: 
+        transform 0.25s ease, 
+        filter 0.3s ease, 
+        opacity 0.3s ease-out, 
+        color 0.3s ease-out !important;
+      color: transparent !important; /* Hide emoji text by default */
+    }
+
+    /* Hover states */
+    #zen-workspaces-button .subviewbutton:hover {
+      transform: scale(1.4) !important;
+      filter: grayscale(0%) !important;
+      opacity: 1 !important;
+      z-index: 3 !important;
+      font-size: 1.35em !important;
+      color: inherit !important;
+    }
+
+    #zen-workspaces-button .subviewbutton:active {
+      background-color: transparent !important;
+      transform: scale(1) !important;
+      filter: grayscale(var(--nebula-workspace-grayscale, 100%)) !important;
+    }
+
+    #zen-workspaces-button .subviewbutton:active:hover {
+      transform: scale(1) !important;
+    }
+
+    #zen-workspaces-button .subviewbutton[active] {
+      background-color: transparent !important;
+      box-shadow: none !important;
+      overflow: unset !important;
+      position: static !important;
+      animation: none !important;
+      filter: grayscale(0%) !important;
+      opacity: 1 !important;
+      color: inherit !important;
+    }
+
+    /* Sibling hover effects */
+    #zen-workspaces-button .subviewbutton:hover + .subviewbutton,
+    #zen-workspaces-button .subviewbutton:has(+ .subviewbutton:hover) {
+      transform: scale(1.15) !important;
+      z-index: 2 !important;
+      opacity: 0.9 !important;
+    }
+
+    #zen-workspaces-button .subviewbutton:hover + .subviewbutton + .subviewbutton,
+    #zen-workspaces-button .subviewbutton:has(+ .subviewbutton + .subviewbutton:hover) {
+      transform: scale(1) !important;
+      z-index: 1 !important;
+      opacity: 0.85 !important;
+    }
+
+    /* Indicator dot */
+    #zen-workspaces-button .subviewbutton::before {
+      content: "•";
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -56.5%);
+      font-size: 2em;
+      color: light-dark(white, rgba(255,255,255,0.35));
+      opacity: 1;
+      pointer-events: none;
+      transition: opacity 0.3s ease;
+    }
+
+    #zen-workspaces-button .subviewbutton:hover::before,
+    #zen-workspaces-button .subviewbutton[active]::before {
+      opacity: 0;
+    }
+  }
+
+  /* Style 2 (Advanced Style) */
+  @media (-moz-int-pref: nebula-workspace-style: 2) {
+    /* Container styling */
+    #zen-workspaces-button {
+      height: 30px !important;
+      width: auto !important;
+      padding: 3px !important;
+      position: relative !important;
+      z-index: 1;
+      border-radius: calc(var(--nebula-border-radius) - 2px) !important;
+      background-color: light-dark(rgba(255,255,255,0.1), rgba(0,0,0,0.2)) !important;
+      box-shadow: 0 2px 12px rgba(0,0,0,0.1) !important;
+      transition: box-shadow 0.35s ease-out, background-color 0.35s ease-out;
+
+      /* --- CORREÇÃO APLICADA --- */
+      /* A propriedade 'overflow: visible' foi removida para permitir a rolagem. */
+      /* As propriedades de rolagem da regra base já se aplicam aqui. */
+    }
+
+    #zen-workspaces-button:hover {
+      box-shadow: 0 2px 12px rgba(0,0,0,0.5) !important;
+      background-color: light-dark(rgba(255,255,255,0.25), rgba(0,0,0,0.35)) !important;
+    }
+
+    /* Style 2 button styling - resets and custom styles */
+    #zen-workspaces-button .subviewbutton {
+      /* Reset defaults */
+      border-radius: unset !important;
+      font-size: unset !important;
+      opacity: unset !important;
+      background-color: transparent !important;
+      box-shadow: none !important;
+      animation: none !important;
+      --toolbarbutton-hover-background: unset !important;
+
+      /* Custom styling */
+      display: flex !important;
+      align-items: center !important;
+      justify-content: center !important;
+      height: 40px !important;
+      border-radius: 12px !important;
+      font-size: 1.25em !important;
+      transform: scale(1) !important;
+      transform-origin: bottom center !important;
+      transition: 
+        transform 0.25s ease, 
+        filter 0.3s ease, 
+        opacity 0.3s ease-out, 
+        color 0.3s ease-out !important;
+      color: transparent !important; /* Hide emoji text by default */
+    }
+
+    /* Hover states */
+    #zen-workspaces-button .subviewbutton:hover {
+      transform: scale(1.4) !important;
+      filter: grayscale(0%) !important;
+      opacity: 1 !important;
+      z-index: 3 !important;
+      font-size: 1.35em !important;
+      color: inherit !important;
+    }
+
+    #zen-workspaces-button .subviewbutton:active {
+      background-color: transparent !important;
+      transform: scale(1) !important;
+      filter: grayscale(var(--nebula-workspace-grayscale, 100%)) !important;
+    }
+
+    #zen-workspaces-button .subviewbutton:active:hover {
+      transform: scale(1) !important;
+    }
+
+    #zen-workspaces-button .subviewbutton[active] {
+      background-color: transparent !important;
+      box-shadow: none !important;
+      overflow: unset !important;
+      position: static !important;
+      animation: none !important;
+      filter: grayscale(0%) !important;
+      opacity: 1 !important;
+      color: inherit !important;
+    }
+
+    /* Sibling hover effects */
+    #zen-workspaces-button .subviewbutton:hover + .subviewbutton,
+    #zen-workspaces-button .subviewbutton:has(+ .subviewbutton:hover) {
+      transform: scale(1.15) !important;
+      z-index: 2 !important;
+      opacity: 0.9 !important;
+    }
+
+    #zen-workspaces-button .subviewbutton:hover + .subviewbutton + .subviewbutton,
+    #zen-workspaces-button .subviewbutton:has(+ .subviewbutton + .subviewbutton:hover) {
+      transform: scale(1) !important;
+      z-index: 1 !important;
+      opacity: 0.85 !important;
+    }
+
+    /* Indicator dot */
+    #zen-workspaces-button .subviewbutton::before {
+      content: "•";
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -56.5%);
+      font-size: 2em;
+      color: light-dark(white, rgba(255,255,255,0.35));
+      opacity: 1;
+      pointer-events: none;
+      transition: opacity 0.3s ease;
+    }
+
+
+    #zen-workspaces-button .subviewbutton:hover::before,
+    #zen-workspaces-button .subviewbutton[active]::before {
+      opacity: 0;
+    }
+  }
+
+  /* ------------------------------ Configuration Options ------------------------------ */
+
+  /* Option to remove workspace name */
+  @media (-moz-bool-pref: "nebula-remove-workspace-indicator") {
+    
+  .zen-current-workspace-indicator {
+    display: none !important;
+  }
+    
+    #zen-tabs-wrapper {
+      padding-top: 4px; /* Add missing padding */
+    }
   }
 }


### PR DESCRIPTION
Added max-width and overflow-x properties to enable horizontal scrolling when workspace buttons overflow. Implemented flex-shrink: 0 to prevent button shrinking. Also removed visible overflow in style variants to maintain consistent scrolling behavior.

in zen twilight when we used zen-zebula and had more than 5 workspaces, they bugged and we couldn't move to any of them, we could only see them all after deleting them all and there were 5 again, if there were more than 5 it would shrink (a lot) and bug the workspaces, here is the fix for this problem.