### PR TITLE
fix, stack split view if another tab opend

### DIFF
--- a/Nebula/modules/Animations(tabs).css
+++ b/Nebula/modules/Animations(tabs).css
@@ -162,7 +162,7 @@
 
 
 @media (-moz-pref("nebula-tab-switch-animation", 5)) {
-  #tabbrowser-tabpanels > hbox:not(:has(.zen-glance-background)):not([zen-split]) {
+  #tabbrowser-tabpanels > hbox:not(:has(.zen-glance-background)):not([zen-split="true"]) {
     transform: scale(1.05);
     filter: blur(15px);
     opacity: 1;
@@ -170,7 +170,7 @@
     will-change: transform, filter, opacity;
   }
 
-  #tabbrowser-tabpanels > hbox.deck-selected:not(:has(.zen-glance-background)):not([zen-split]) {
+  #tabbrowser-tabpanels > hbox.deck-selected:not(:has(.zen-glance-background)):not([zen-split="true"]) {
     transform: scale(1);
     opacity: 1 !important;
     filter: none !important;


### PR DESCRIPTION
a small typo caused every split window to stack (every click was send to the last open tab) when the face animation was active.